### PR TITLE
upgrade `multidms` to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
-# version 3.0.0
+# CHANGELOG
+
+#### version 3.0.1
+- Upgrade ``multidms`` to version 0.1.6, which fixes error with letter-suffixed site numbers.
+
+## version 3.0.0
 This is a total re-write of the pipeline in a new repository, replacing versions 1 and 2 that are still available at [https://github.com/dms-vep/dms-vep-pipeline](https://github.com/dms-vep/dms-vep-pipeline).
 There are numerous changes to the pipeline structure in version 3 relative to versions 1 and 2, although much of the logic of the pipeline is the same.

--- a/environment.yml
+++ b/environment.yml
@@ -34,5 +34,5 @@ dependencies:
   - pip:
     - alignparse==0.6.2
     - dms_variants==1.4.3
-    - git+https://github.com/matsengrp/multidms@ada8cda3847543ee3b0a5d5acf06927eae9bd06b
+    - git+https://github.com/matsengrp/multidms@0.1.6
     - polyclonal==6.2

--- a/notebooks/func_effects_global_epistasis.ipynb
+++ b/notebooks/func_effects_global_epistasis.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = multidms.MultiDmsData(\n",
+    "data = multidms.Data(\n",
     "    variants_df=func_scores_df,\n",
     "    reference=selection,\n",
     "    alphabet=multidms.AAS_WITHSTOP_WITHGAP,\n",
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "# initialize with default params, which give sigmoid global epistasis function\n",
-    "model = multidms.MultiDmsModel(data)\n",
+    "model = multidms.Model(data)\n",
     "\n",
     "model.fit()"
    ]


### PR DESCRIPTION
Fixes error caused by use of letter-suffixed sites.

Becomes `dms-vep-pipeline` version 3.0.1.