### PR TITLE
fix bug in `avg_func_effect_shifts` when lasso penalty in scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.1.3
+- Fixed a bug in `avg_func_effect_shifts` when lasso penalty is in scientific notation.
+
 #### version 3.1.2
 - Upgrade to `polyclonal` 6.5.
 

--- a/notebooks/avg_func_effect_shifts.ipynb
+++ b/notebooks/avg_func_effect_shifts.ipynb
@@ -76,7 +76,8 @@
     "\n",
     "shifts = [\n",
     "    pd.read_csv(f\"results/func_effect_shifts/by_comparison/{c}_shifts.csv\").assign(\n",
-    "        comparison=c\n",
+    "        comparison=c,\n",
+    "        lasso_shift=lambda x: x[\"lasso_shift\"].astype(float),\n",
     "    )\n",
     "    for c in comparisons\n",
     "]\n",
@@ -192,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lasso_shift = params[\"lasso_shift\"]\n",
+    "lasso_shift = float(params[\"lasso_shift\"])\n",
     "avg_method = params[\"avg_method\"]\n",
     "\n",
     "assert lasso_shift in set(shifts_comparison_pivoted[\"lasso_shift\"])\n",


### PR DESCRIPTION
@Caleb-Carr, this should fix #27. Re-open the issue and let me know if it does not. 