### PR TITLE
internal restructure so altair formatting common rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### version 3.2.0
+- Internally restructured to re-use a single rule for formatting altair plots by creating `common.smk` and then putting the `format_altair_html` rule there and removing plot-specific versions of that rule.
+
 #### version 3.1.3
 - Fixed a bug in `avg_func_effect_shifts` when lasso penalty is in scientific notation.
 

--- a/Snakefile
+++ b/Snakefile
@@ -3,6 +3,7 @@
 
 import collections
 import os
+import re
 
 import flatdict
 
@@ -78,6 +79,7 @@ docs = {}
 
 # include pipeline rules, which also add to `docs` dictionary
 include: "build_variants.smk"
+include: "common.smk"
 
 
 if len(barcode_runs) > 0:

--- a/antibody_escape.smk
+++ b/antibody_escape.smk
@@ -176,40 +176,6 @@ rule avg_antibody_escape:
         """
 
 
-rule format_avg_antibody_escape_charts:
-    """Format ``altair`` antibody escape charts."""
-    input:
-        html="results/antibody_escape/averages/{antibody}_mut_{metric}_nolegend.html",
-        pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
-    output:
-        html="results/antibody_escape/averages/{antibody}_mut_{metric}.html",
-        legend=temp("results/antibody_escape/averages/{antibody}_mut_{metric}.md"),
-    wildcard_constraints:
-        metric="escape|icXX",
-    params:
-        title=lambda wc: avg_antibody_escape_config[wc.antibody]["title"],
-        legend=lambda wc: avg_antibody_escape_config[wc.antibody]["legend"],
-        suffix=(
-            f"Analysis by {config['authors']} ({config['year']}).\n\n See "
-            f"[{config['github_repo_url']}]({config['github_repo_url']}) for code/data."
-        ),
-    conda:
-        "environment.yml"
-    log:
-        "results/logs/format_avg_antibody_escape_charts_{antibody}_mut_{metric}.txt",
-    shell:
-        """
-        echo "## {params.title}\n" > {output.legend}
-        echo "{params.legend}\n\n" >> {output.legend}
-        echo "{params.suffix}" >> {output.legend}
-        python {input.pyscript} \
-            --chart {input.html} \
-            --markdown {output.legend} \
-            --title "{params.title}" \
-            --output {output.html}
-        """
-
-
 for heading, fname in [
     ("Average selections for antibody/serum", rules.avg_antibody_escape.output.nb),
     (

--- a/common.smk
+++ b/common.smk
@@ -1,0 +1,35 @@
+"""Common rules used in multiple ``snakemake`` ``*.smk`` files in pipeline."""
+
+
+include: "common_funcs.smk"
+
+
+rule format_altair_html:
+    """Format ``altair`` charts by adding title, legend, etc."""
+    input:
+        html="{chart}_nolegend.html",
+        pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
+    output:
+        html="{chart}.html",
+        legend=temp("{chart}.md"),
+    params:
+        chart_params=format_altair_html_chart_params,
+        suffix=(
+            f"Analysis by {config['authors']} ({config['year']}).\n\n See "
+            f"[{config['github_repo_url']}]({config['github_repo_url']}) for code/data."
+        ),
+    conda:
+        "environment.yml"
+    log:
+        "results/logs/{chart}.txt",
+    shell:
+        """
+        echo "## {params.chart_params[title]}\n" > {output.legend}
+        echo "{params.chart_params[legend]}\n\n" >> {output.legend}
+        echo "{params.suffix}" >> {output.legend}
+        python {input.pyscript} \
+            --chart {input.html} \
+            --markdown {output.legend} \
+            --title "{params.chart_params[title]}" \
+            --output {output.html}
+        """

--- a/common_funcs.smk
+++ b/common_funcs.smk
@@ -1,0 +1,37 @@
+"""Functions for ``common.smk``."""
+
+
+def format_altair_html_chart_params(wc):
+    """Get parameters used in ``format_altair_html``."""
+    chart = wc.chart
+    if m := re.fullmatch(
+        "results/func_effects/averages/(?P<condition>.+)_(?P<pheno>func|latent)_effects",
+        chart,
+    ):
+        condition = m.group("condition")
+        pheno = m.group("pheno")
+        title = (
+            func_effects_config["avg_func_effects"][condition]["title"]
+            + {
+                "func": " (functional score)",
+                "latent": " (latent phenotype)",
+            }[pheno]
+        )
+        legend = (func_effects_config["avg_func_effects"][condition]["legend"],)
+    elif m := re.fullmatch(
+        "results/func_effect_shifts/averages/(?P<comparison>.+)_shifts",
+        chart,
+    ):
+        comparison = m.group("comparison")
+        title = avg_func_effect_shifts[comparison]["title"]
+        legend = avg_func_effect_shifts[comparison]["legend"]
+    elif m := re.fullmatch(
+        "results/antibody_escape/averages/(?P<antibody>.+)_mut_(?:escape|icXX)",
+        chart,
+    ):
+        antibody = m.group("antibody")
+        title = avg_antibody_escape_config[antibody]["title"]
+        legend = avg_antibody_escape_config[antibody]["legend"]
+    else:
+        raise ValueError(f"could not get formatting params for {chart=}")
+    return {"title": title, "legend": legend}

--- a/func_effects.smk
+++ b/func_effects.smk
@@ -182,48 +182,6 @@ func_effects_docs["Average mutation latent-phenotype effects (CSV files)"] = {
     for c in func_effects_config["avg_func_effects"]
 }
 
-
-rule format_avg_func_effects_chart:
-    """Format ``altair`` average functional effects chart."""
-    input:
-        html="results/func_effects/averages/{condition}_{pheno}_effects_nolegend.html",
-        pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
-    output:
-        html="results/func_effects/averages/{condition}_{pheno}_effects.html",
-        legend=temp("results/func_effects/averages/{condition}_{pheno}_effects.md"),
-    wildcard_constraints:
-        pheno="func|latent",
-    params:
-        title=lambda wc: (
-            func_effects_config["avg_func_effects"][wc.condition]["title"]
-            + {"func": " (functional score)", "latent": " (latent phenotype)"}[
-                wc.pheno
-            ]
-        ),
-        legend=lambda wc: func_effects_config["avg_func_effects"][wc.condition][
-            "legend"
-        ],
-        suffix=(
-            f"Analysis by {config['authors']} ({config['year']}).\n\n See "
-            f"[{config['github_repo_url']}]({config['github_repo_url']}) for code/data."
-        ),
-    conda:
-        "environment.yml"
-    log:
-        "results/logs/format_avg_func_effects_chart_{condition}_{pheno}.txt",
-    shell:
-        """
-        echo "## {params.title}\n" > {output.legend}
-        echo "{params.legend}\n\n" >> {output.legend}
-        echo "{params.suffix}" >> {output.legend}
-        python {input.pyscript} \
-            --chart {input.html} \
-            --markdown {output.legend} \
-            --title "{params.title}" \
-            --output {output.html}
-        """
-
-
 func_effects_docs["Interactive plots of average mutation functional effects"] = {
     c: f"results/func_effects/averages/{c}_func_effects.html"
     for c in func_effects_config["avg_func_effects"]
@@ -324,38 +282,6 @@ rule avg_func_effect_shifts:
         """
 
 
-rule format_avg_func_effect_shifts_chart:
-    """Format ``altair`` average functional effect shifts chart."""
-    input:
-        html=rules.avg_func_effect_shifts.output.shifts_html,
-        pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
-    output:
-        html="results/func_effect_shifts/averages/{comparison}_shifts.html",
-        legend=temp("results/func_effect_shifts/averages/{comparison}_shifts.md"),
-    params:
-        title=lambda wc: avg_func_effect_shifts[wc.comparison]["title"],
-        legend=lambda wc: avg_func_effect_shifts[wc.comparison]["legend"],
-        suffix=(
-            f"Analysis by {config['authors']} ({config['year']}).\n\n See "
-            f"[{config['github_repo_url']}]({config['github_repo_url']}) for code/data."
-        ),
-    conda:
-        "environment.yml"
-    log:
-        "results/logs/format_avg_func_effect_shifts_chart_{comparison}.txt",
-    shell:
-        """
-        echo "## {params.title}\n" > {output.legend}
-        echo "{params.legend}\n\n" >> {output.legend}
-        echo "{params.suffix}" >> {output.legend}
-        python {input.pyscript} \
-            --chart {input.html} \
-            --markdown {output.legend} \
-            --title "{params.title}" \
-            --output {output.html}
-        """
-
-
 if avg_func_effect_shifts:
     func_effects_docs["Notebooks averaging shifts in functional effects"] = {
         c: rules.avg_func_effect_shifts.output.nb.format(comparison=c)
@@ -366,7 +292,9 @@ if avg_func_effect_shifts:
         for c in avg_func_effect_shifts
     }
     func_effects_docs["Interactive plots of average shifts in functional effects"] = {
-        c: rules.format_avg_func_effect_shifts_chart.output.html.format(comparison=c)
+        c: "results/func_effect_shifts/averages/{comparison}_shifts.html".format(
+            comparison=c
+        )
         for c in avg_func_effect_shifts
     }
 


### PR DESCRIPTION
Add `common.smk` with common rules.

Then put `format_altair_html` in these common rules, and removed other formatting rules.