### PR TITLE
Constrain wildcards in `format_altair_html` to better enable custom rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.2.1
+- Constrain wildcards in `format_altair_html` to better enable custom rules
+
 ### version 3.2.0
 - Generalize `antibody_escape` to also allow receptor affinity selections with soluble receptor.
 - Changed output of `avg_escape` rules for antibodies to be `mut_effect` rather than `mut_escape`. This is because `effect` can generally refer to other phenotypes too.

--- a/common.smk
+++ b/common.smk
@@ -7,11 +7,11 @@ include: "common_funcs.smk"
 rule format_altair_html:
     """Format ``altair`` charts by adding title, legend, etc."""
     input:
-        html="{chart}_nolegend.html",
+        html="results/{chart}_nolegend.html",
         pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),
     output:
-        html="{chart}.html",
-        legend=temp("{chart}.md"),
+        html="results/{chart}.html",
+        legend=temp("results/{chart}.md"),
     params:
         chart_params=format_altair_html_chart_params,
         suffix=(

--- a/common_funcs.smk
+++ b/common_funcs.smk
@@ -5,7 +5,7 @@ def format_altair_html_chart_params(wc):
     """Get parameters used in ``format_altair_html``."""
     chart = wc.chart
     if m := re.fullmatch(
-        "results/func_effects/averages/(?P<condition>.+)_(?P<pheno>func|latent)_effects",
+        "func_effects/averages/(?P<condition>.+)_(?P<pheno>func|latent)_effects",
         chart,
     ):
         condition = m.group("condition")
@@ -19,14 +19,14 @@ def format_altair_html_chart_params(wc):
         )
         legend = (func_effects_config["avg_func_effects"][condition]["legend"],)
     elif m := re.fullmatch(
-        "results/func_effect_shifts/averages/(?P<comparison>.+)_shifts",
+        "func_effect_shifts/averages/(?P<comparison>.+)_shifts",
         chart,
     ):
         comparison = m.group("comparison")
         title = avg_func_effect_shifts[comparison]["title"]
         legend = avg_func_effect_shifts[comparison]["legend"]
     elif m := re.fullmatch(
-        "results/(?P<assay>antibody_escape|receptor_affinity)/"
+        "(?P<assay>antibody_escape|receptor_affinity)/"
         + "averages/(?P<antibody>.+)_mut_(?:effect|icXX)",
         chart,
     ):


### PR DESCRIPTION
This better enables using of HTMLs in `custom_rules.smk`.

Becomes version 3.2.1