### PR TITLE
Add `other_target_files` to make other files pipeline targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.2.3
+- Add `other_target_files` variable: files can be added to this (eg, in `custom_rules.smk`) and then the pipeline will ensure these files are also created. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/39).
+
 #### version 3.2.2
 - Add `min_filters` to `plot_hide_stats` in `antibody_escape_config.yaml` to only hide/filter robustly measured values.
 

--- a/Snakefile
+++ b/Snakefile
@@ -80,6 +80,7 @@ docs = {}
 # other output target files
 other_target_files = []
 
+
 # include pipeline rules, which also add to `docs` dictionary
 include: "build_variants.smk"
 include: "common.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -77,6 +77,8 @@ sample_to_date = (
 # make further additions of course.
 docs = {}
 
+# other output target files
+other_target_files = []
 
 # include pipeline rules, which also add to `docs` dictionary
 include: "build_variants.smk"
@@ -116,3 +118,4 @@ rule all:
     input:
         rules.build_docs.input,
         os.path.join(config["docs"], "index.html"),
+        *other_target_files,

--- a/test_example/custom_rules.smk
+++ b/test_example/custom_rules.smk
@@ -29,3 +29,7 @@ rule spatial_distances:
 docs["Additional analysis-specific files"] = {
     "Reference to sequential site-numbering map": config["site_numbering_map"],
 }
+
+# If you want to make other output files from your rules target files for
+# the pipeline, add them to `other_target_files` list
+other_target_files.append(rules.spatial_distances.output.pdb)


### PR DESCRIPTION
Files can be added to `other_target_rules` list (eg, in `custom_rules.smk`) and then the pipeline will ensure these files are also created.

Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/39).