### PR TITLE
de-clutter HTML docs by arranging into subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 #### version 3.2.3
+- De-clutter the HTML docs by creating subsections that separate the "Final summary plots", "Analysis notebooks", and "Data files". Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/41).
 - Add `other_target_files` variable: files can be added to this (eg, in `custom_rules.smk`) and then the pipeline will ensure these files are also created. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/39).
 - Updated to `polyclonal` 6.7, which addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/40) and [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/43).
 

--- a/build_variants.smk
+++ b/build_variants.smk
@@ -1,13 +1,9 @@
 """``snakemake`` files with rules for building variants."""
 
 
-# Names and values of files to add to docs
-build_variants_docs = {
-    "parental codon sequence": config["gene_sequence_codon"],
-    "parental protein sequence": config["gene_sequence_protein"],
-    "barcode to codon-variant lookup table": config["codon_variants"],
-}
-    
+build_variants_docs = {}
+
+
 rule translate_geneseq:
     """Translate gene sequence into protein sequence."""
     input:
@@ -38,7 +34,7 @@ elif config["prebuilt_variants"] and config["prebuilt_geneseq"]:
         conda:
             "environment.yml"
         log:
-            "results/logs/get_prebuilt_variants.txt"
+            "results/logs/get_prebuilt_variants.txt",
         shell:
             """
             curl -o {output.variants} {params.variants_url} &> {log}
@@ -46,13 +42,16 @@ elif config["prebuilt_variants"] and config["prebuilt_geneseq"]:
             """
 
 else:
-
     pacbio_runs = pd.read_csv(config["pacbio_runs"])
     pacbio_runs_required_columns = {"library", "run", "fastq"}
     if not pacbio_runs_required_columns.issubset(pacbio_runs.columns):
-        raise ValueError(f"{pacbio_runs.columns=} lacks {pacbio_runs_required_columns=}")
+        raise ValueError(
+            f"{pacbio_runs.columns=} lacks {pacbio_runs_required_columns=}"
+        )
     if len(pacbio_runs) != pacbio_runs["run"].nunique():
-        raise ValueError(f"duplicates in 'run' column of `pacbio_runs`\n\n{pacbio_runs}")
+        raise ValueError(
+            f"duplicates in 'run' column of `pacbio_runs`\n\n{pacbio_runs}"
+        )
 
     rule gene_sequence:
         """Get sequence of gene from PacBio amplicon."""
@@ -63,10 +62,9 @@ else:
         conda:
             "environment.yml"
         log:
-           "results/logs/gene_sequence.txt",
+            "results/logs/gene_sequence.txt",
         script:
             "scripts/gene_sequence.py"
-
 
     rule align_parse_PacBio_ccs:
         """Align and parse PacBio CCS FASTQ file."""
@@ -79,10 +77,9 @@ else:
         conda:
             "environment.yml"
         log:
-            "results/logs/align_parse_PacBio_ccs_{pacbioRun}.txt"
+            "results/logs/align_parse_PacBio_ccs_{pacbioRun}.txt",
         script:
             "scripts/align_parse_PacBio_ccs.py"
-
 
     rule analyze_pacbio_ccs:
         """Analyze PacBio CCSs and get ones that align to amplicons of interest."""
@@ -93,19 +90,18 @@ else:
             ),
             config["pacbio_amplicon"],
             config["pacbio_amplicon_specs"],
-            nb=os.path.join(config["pipeline_path"], "notebooks/analyze_pacbio_ccs.ipynb"),
+            nb=os.path.join(
+                config["pipeline_path"], "notebooks/analyze_pacbio_ccs.ipynb"
+            ),
         output:
             csv="results/process_ccs/CCSs_aligned_to_amplicon.csv",
             nb="results/notebooks/analyze_pacbio_ccs.ipynb",
         conda:
             "environment.yml"
         log:
-            "results/logs/analyze_pacbio_ccs.txt"
+            "results/logs/analyze_pacbio_ccs.txt",
         shell:
             "papermill {input.nb} {output.nb} &> {log}"
-
-    build_variants_docs["Analysis of PacBio CCSs"] = rules.analyze_pacbio_ccs.output.nb
-
 
     rule build_pacbio_consensus:
         """Build PacBio consensus sequences for barcodes."""
@@ -124,14 +120,9 @@ else:
         conda:
             "environment.yml"
         log:
-            "results/logs/build_pacbio_consensus.txt"
+            "results/logs/build_pacbio_consensus.txt",
         shell:
             "papermill {input.nb} {output.nb} &> {log}"
-
-    build_variants_docs[
-        "Building of consensus sequences for barcoded variants"
-    ] = rules.build_pacbio_consensus.output.nb
-
 
     rule build_codon_variants:
         """Build codon-variant table."""
@@ -142,7 +133,9 @@ else:
             config["site_numbering_map"],
             config["mutation_design_classification"]["csv"],
             config["neut_standard_barcodes"],
-            nb=os.path.join(config["pipeline_path"], "notebooks/build_codon_variants.ipynb"),
+            nb=os.path.join(
+                config["pipeline_path"], "notebooks/build_codon_variants.ipynb"
+            ),
         output:
             config["codon_variants"],
             nb="results/notebooks/build_codon_variants.ipynb",
@@ -151,12 +144,22 @@ else:
         conda:
             "environment.yml"
         log:
-            "results/logs/build_codon_variants.txt"
+            "results/logs/build_codon_variants.txt",
         shell:
             "papermill {input.nb} {output.nb} &> {log}"
 
-    build_variants_docs[
-        "Building of codon-variant table"
-    ] = rules.build_codon_variants.output.nb
+    build_variants_docs["Analysis notebooks"] = {
+        "Analysis of PacBio CCSs": rules.analyze_pacbio_ccs.output.nb,
+        "Building barcoded variant consensus sequences": rules.build_pacbio_consensus.output.nb,
+        "Building of codon-variant table": rules.build_codon_variants.output.nb,
+    }
+
+
+# Names and values of files to add to docs
+build_variants_docs["Data files"] = {
+    "parental codon sequence": config["gene_sequence_codon"],
+    "parental protein sequence": config["gene_sequence_protein"],
+    "barcode to codon-variant lookup table": config["codon_variants"],
+}
 
 docs["Barcode to codon-variant lookup table"] = build_variants_docs

--- a/count_variants.smk
+++ b/count_variants.smk
@@ -2,7 +2,10 @@
 
 
 # Names and values of files to add to docs
-count_variants_docs = collections.defaultdict(dict)
+count_variants_docs = {
+    "Analysis notebooks": collections.defaultdict(dict),
+    "Data files": collections.defaultdict(dict),
+}
 
 
 rule count_barcodes:
@@ -26,7 +29,7 @@ rule count_barcodes:
 
 
 for sample in barcode_runs["sample"]:
-    count_variants_docs["Barcode counts"][sample] = os.path.join(
+    count_variants_docs["Data files"]["Barcode count CSVs"][sample] = os.path.join(
         "results/barcode_counts",
         f"{sample}_counts.csv",
     )
@@ -56,9 +59,9 @@ rule analyze_variant_counts:
         "papermill {input.nb} {output.nb} &> {log}"
 
 
-count_variants_docs[
+count_variants_docs["Analysis notebooks"][
     "Analysis of variant counts"
 ] = rules.analyze_variant_counts.output.nb
 
 
-docs["Count variants"] = count_variants_docs
+docs["Count barcodes for variants"] = count_variants_docs

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <p>See <a href="https://github.com/dms-vep/dms-vep-pipeline-3">https://github.com/dms-vep/dms-vep-pipeline-3</a> for full code.</p>
 <div class="toc"><span class="toctitle">Contents</span><ul>
 <li><a href="#barcode-to-codon-variant-lookup-table">Barcode to codon-variant lookup table</a></li>
-<li><a href="#count-variants">Count variants</a></li>
+<li><a href="#count-barcodes-for-variants">Count barcodes for variants</a></li>
 <li><a href="#functional-effects-of-mutations">Functional effects of mutations</a></li>
 <li><a href="#antibodyserum-escape">Antibody/serum escape</a></li>
 <li><a href="#receptor-affinity">Receptor affinity</a></li>
@@ -11,17 +11,26 @@
 </ul>
 </div>
 <h2 id="barcode-to-codon-variant-lookup-table">Barcode to codon-variant lookup table</h2>
+<h4 id="analysis-notebooks">Analysis notebooks</h4>
+<ul>
+<li><a href="notebooks/analyze_pacbio_ccs.html">Analysis of PacBio CCSs</a></li>
+<li><a href="notebooks/build_pacbio_consensus.html">Building barcoded variant consensus sequences</a></li>
+<li><a href="notebooks/build_codon_variants.html">Building of codon-variant table</a></li>
+</ul>
+<h4 id="data-files">Data files</h4>
 <ul>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/gene_sequence/codon.fasta">parental codon sequence</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/gene_sequence/protein.fasta">parental protein sequence</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/variants/codon_variants.csv">barcode to codon-variant lookup table</a></li>
-<li><a href="notebooks/analyze_pacbio_ccs.html">Analysis of PacBio CCSs</a></li>
-<li><a href="notebooks/build_pacbio_consensus.html">Building of consensus sequences for barcoded variants</a></li>
-<li><a href="notebooks/build_codon_variants.html">Building of codon-variant table</a></li>
 </ul>
-<h2 id="count-variants">Count variants</h2>
+<h2 id="count-barcodes-for-variants">Count barcodes for variants</h2>
+<h4 id="analysis-notebooks_1">Analysis notebooks</h4>
 <ul>
-<li><details><summary>Barcode counts (click triangle to expand/collapse)</summary><ul>
+<li><a href="notebooks/analyze_variant_counts.html">Analysis of variant counts</a></li>
+</ul>
+<h4 id="data-files_1">Data files</h4>
+<ul>
+<li><details><summary>Barcode count CSVs (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/barcode_counts/LibA-220210-REGN10933-0.15-1_counts.csv">LibA-220210-REGN10933-0.15-1</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/barcode_counts/LibA-220210-REGN10933-1.39-1_counts.csv">LibA-220210-REGN10933-1.39-1</a></li>
@@ -49,20 +58,31 @@
 </ul></details>
 
 </li>
-<li><a href="notebooks/analyze_variant_counts.html">Analysis of variant counts</a></li>
 </ul>
 <h2 id="functional-effects-of-mutations">Functional effects of mutations</h2>
+<h4 id="final-summary-plots">Final summary plots</h4>
 <ul>
-<li><details><summary>Per-variant functional score CSVs (click triangle to expand/collapse)</summary><ul>
+<li><details><summary>Interactive plots of average mutation functional effects (click triangle to expand/collapse)</summary><ul>
 
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220210-293T_ACE2-1_func_scores.csv">LibA-220210-293T_ACE2-1</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220210-293T_ACE2-2_func_scores.csv">LibA-220210-293T_ACE2-2</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220302-293T_ACE2-1_func_scores.csv">LibA-220302-293T_ACE2-1</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220302-293T_ACE2-2_func_scores.csv">LibA-220302-293T_ACE2-2</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibB-220302-293T_ACE2-1_func_scores.csv">LibB-220302-293T_ACE2-1</a></li>
+<li><a href="htmls/293T_ACE2_entry_func_effects.html">293T_ACE2_entry</a></li>
 </ul></details>
 
 </li>
+<li><details><summary>Interactive plots of average mutation latent-phenotype effects (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="htmls/293T_ACE2_entry_latent_effects.html">293T_ACE2_entry</a></li>
+</ul></details>
+
+</li>
+<li><details><summary>Interactive plots of average shifts in functional effects (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="htmls/date_comparison_shifts.html">date_comparison</a></li>
+</ul></details>
+
+</li>
+</ul>
+<h4 id="analysis-notebooks_2">Analysis notebooks</h4>
+<ul>
 <li><a href="notebooks/analyze_func_scores.html">Analysis of functional scores</a></li>
 <li><details><summary>Notebooks with per-selection global epistasis fitting (click triangle to expand/collapse)</summary><ul>
 
@@ -74,6 +94,38 @@
 </ul></details>
 
 </li>
+<li><details><summary>Notebooks averaging mutation functional effects (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="notebooks/avg_func_effects_293T_ACE2_entry.html">293T_ACE2_entry</a></li>
+</ul></details>
+
+</li>
+<li><details><summary>Notebooks fitting shifts in functional effects (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="notebooks/func_effect_shifts_LibA-date_comparison-1.html">LibA-date_comparison-1</a></li>
+<li><a href="notebooks/func_effect_shifts_LibA-date_comparison-2.html">LibA-date_comparison-2</a></li>
+</ul></details>
+
+</li>
+<li><details><summary>Notebooks averaging shifts in functional effects (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="notebooks/avg_func_effect_shifts_date_comparison.html">date_comparison</a></li>
+</ul></details>
+
+</li>
+</ul>
+<h4 id="data-files_2">Data files</h4>
+<ul>
+<li><details><summary>Per-variant functional score CSVs (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220210-293T_ACE2-1_func_scores.csv">LibA-220210-293T_ACE2-1</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220210-293T_ACE2-2_func_scores.csv">LibA-220210-293T_ACE2-2</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220302-293T_ACE2-1_func_scores.csv">LibA-220302-293T_ACE2-1</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibA-220302-293T_ACE2-2_func_scores.csv">LibA-220302-293T_ACE2-2</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_scores/LibB-220302-293T_ACE2-1_func_scores.csv">LibB-220302-293T_ACE2-1</a></li>
+</ul></details>
+
+</li>
 <li><details><summary>Per-selection mutation functional effect CSVs (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effects/by_selection/LibA-220210-293T_ACE2-1_func_effects.csv">LibA-220210-293T_ACE2-1</a></li>
@@ -81,12 +133,6 @@
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effects/by_selection/LibA-220302-293T_ACE2-1_func_effects.csv">LibA-220302-293T_ACE2-1</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effects/by_selection/LibA-220302-293T_ACE2-2_func_effects.csv">LibA-220302-293T_ACE2-2</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effects/by_selection/LibB-220302-293T_ACE2-1_func_effects.csv">LibB-220302-293T_ACE2-1</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>Notebooks averaging mutation functional effects (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="notebooks/avg_func_effects_293T_ACE2_entry.html">293T_ACE2_entry</a></li>
 </ul></details>
 
 </li>
@@ -102,35 +148,10 @@
 </ul></details>
 
 </li>
-<li><details><summary>Interactive plots of average mutation functional effects (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/293T_ACE2_entry_func_effects.html">293T_ACE2_entry</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>Interactive plots of average mutation latent-phenotype effects (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/293T_ACE2_entry_latent_effects.html">293T_ACE2_entry</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>Notebooks fitting shifts in functional effects (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="notebooks/func_effect_shifts_LibA-date_comparison-1.html">LibA-date_comparison-1</a></li>
-<li><a href="notebooks/func_effect_shifts_LibA-date_comparison-2.html">LibA-date_comparison-2</a></li>
-</ul></details>
-
-</li>
 <li><details><summary>Per-condition functional effect shifts CSVs (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effect_shifts/by_comparison/LibA-date_comparison-1_shifts.csv">LibA-date_comparison-1</a></li>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/func_effect_shifts/by_comparison/LibA-date_comparison-2_shifts.csv">LibA-date_comparison-2</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>Notebooks averaging shifts in functional effects (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="notebooks/avg_func_effect_shifts_date_comparison.html">date_comparison</a></li>
 </ul></details>
 
 </li>
@@ -140,14 +161,46 @@
 </ul></details>
 
 </li>
-<li><details><summary>Interactive plots of average shifts in functional effects (click triangle to expand/collapse)</summary><ul>
+</ul>
+<h2 id="antibodyserum-escape">Antibody/serum escape</h2>
+<h4 id="final-summary-plots_1">Final summary plots</h4>
+<ul>
+<li><details><summary>antibody escape mutation effect plots (click triangle to expand/collapse)</summary><ul>
 
-<li><a href="htmls/date_comparison_shifts.html">date_comparison</a></li>
+<li><a href="htmls/REGN10933_mut_effect.html">REGN10933</a></li>
+<li><a href="htmls/S2M11_mut_effect.html">S2M11</a></li>
+</ul></details>
+
+</li>
+<li><details><summary>antibody escape mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="htmls/REGN10933_mut_icXX.html">REGN10933</a></li>
+<li><a href="htmls/S2M11_mut_icXX.html">S2M11</a></li>
 </ul></details>
 
 </li>
 </ul>
-<h2 id="antibodyserum-escape">Antibody/serum escape</h2>
+<h4 id="analysis-notebooks_3">Analysis notebooks</h4>
+<ul>
+<li><details><summary>Fits of polyclonal models to individual antibody escape selections (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="notebooks/fit_escape_antibody_escape_LibA-220210-REGN10933-1.html">LibA-220210-REGN10933-1</a></li>
+<li><a href="notebooks/fit_escape_antibody_escape_LibA-220210-REGN10933-2.html">LibA-220210-REGN10933-2</a></li>
+<li><a href="notebooks/fit_escape_antibody_escape_LibB-220302-REGN10933-1.html">LibB-220302-REGN10933-1</a></li>
+<li><a href="notebooks/fit_escape_antibody_escape_LibA-220302-S2M11-1.html">LibA-220302-S2M11-1</a></li>
+<li><a href="notebooks/fit_escape_antibody_escape_LibA-220302-S2M11-2.html">LibA-220302-S2M11-2</a></li>
+</ul></details>
+
+</li>
+<li><details><summary>Average selections for antibody escape (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="notebooks/avg_escape_antibody_escape_REGN10933.html">REGN10933</a></li>
+<li><a href="notebooks/avg_escape_antibody_escape_S2M11.html">S2M11</a></li>
+</ul></details>
+
+</li>
+</ul>
+<h4 id="data-files_3">Data files</h4>
 <ul>
 <li><details><summary>Probability (fraction) escape for each variant in each antibody escape selection (CSVs) (click triangle to expand/collapse)</summary><ul>
 
@@ -169,23 +222,6 @@
 </ul></details>
 
 </li>
-<li><details><summary>Fits of polyclonal models to individual antibody escape selections (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="notebooks/fit_escape_antibody_escape_LibA-220210-REGN10933-1.html">LibA-220210-REGN10933-1</a></li>
-<li><a href="notebooks/fit_escape_antibody_escape_LibA-220210-REGN10933-2.html">LibA-220210-REGN10933-2</a></li>
-<li><a href="notebooks/fit_escape_antibody_escape_LibB-220302-REGN10933-1.html">LibB-220302-REGN10933-1</a></li>
-<li><a href="notebooks/fit_escape_antibody_escape_LibA-220302-S2M11-1.html">LibA-220302-S2M11-1</a></li>
-<li><a href="notebooks/fit_escape_antibody_escape_LibA-220302-S2M11-2.html">LibA-220302-S2M11-2</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>Average selections for antibody escape (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="notebooks/avg_escape_antibody_escape_REGN10933.html">REGN10933</a></li>
-<li><a href="notebooks/avg_escape_antibody_escape_S2M11.html">S2M11</a></li>
-</ul></details>
-
-</li>
 <li><details><summary>antibody escape CSVs (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/antibody_escape/averages/REGN10933_mut_effect.csv">REGN10933</a></li>
@@ -200,34 +236,25 @@
 </ul></details>
 
 </li>
-<li><details><summary>antibody escape mutation effect plots (click triangle to expand/collapse)</summary><ul>
+</ul>
+<h2 id="receptor-affinity">Receptor affinity</h2>
+<h4 id="final-summary-plots_2">Final summary plots</h4>
+<ul>
+<li><details><summary>receptor affinity mutation effect plots (click triangle to expand/collapse)</summary><ul>
 
-<li><a href="htmls/REGN10933_mut_effect.html">REGN10933</a></li>
-<li><a href="htmls/S2M11_mut_effect.html">S2M11</a></li>
+<li><a href="htmls/pretending_S2M11_is_receptor_mut_effect.html">pretending_S2M11_is_receptor</a></li>
 </ul></details>
 
 </li>
-<li><details><summary>antibody escape mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
+<li><details><summary>receptor affinity mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
 
-<li><a href="htmls/REGN10933_mut_icXX.html">REGN10933</a></li>
-<li><a href="htmls/S2M11_mut_icXX.html">S2M11</a></li>
+<li><a href="htmls/pretending_S2M11_is_receptor_mut_icXX.html">pretending_S2M11_is_receptor</a></li>
 </ul></details>
 
 </li>
 </ul>
-<h2 id="receptor-affinity">Receptor affinity</h2>
+<h4 id="analysis-notebooks_4">Analysis notebooks</h4>
 <ul>
-<li><details><summary>Probability (fraction) escape for each variant in each receptor affinity selection (CSVs) (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-0.3082-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-0.3082-1</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-1.2328-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-1.2328-1</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-4.9314-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-4.9314-1</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-0.3082-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-0.3082-2</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-1.2328-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-1.2328-2</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-4.9314-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-4.9314-2</a></li>
-</ul></details>
-
-</li>
 <li><details><summary>Fits of polyclonal models to individual receptor affinity selections (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="notebooks/fit_escape_receptor_affinity_LibA-220302-pretending_S2M11_is_receptor-1.html">LibA-220302-pretending_S2M11_is_receptor-1</a></li>
@@ -238,6 +265,20 @@
 <li><details><summary>Average selections for receptor affinity (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="notebooks/avg_escape_receptor_affinity_pretending_S2M11_is_receptor.html">pretending_S2M11_is_receptor</a></li>
+</ul></details>
+
+</li>
+</ul>
+<h4 id="data-files_4">Data files</h4>
+<ul>
+<li><details><summary>Probability (fraction) escape for each variant in each receptor affinity selection (CSVs) (click triangle to expand/collapse)</summary><ul>
+
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-0.3082-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-0.3082-1</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-1.2328-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-1.2328-1</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-1/LibA-220302-S2M11-4.9314-1_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-1 LibA-220302-S2M11-4.9314-1</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-0.3082-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-0.3082-2</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-1.2328-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-1.2328-2</a></li>
+<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/by_selection/LibA-220302-pretending_S2M11_is_receptor-2/LibA-220302-S2M11-4.9314-2_prob_escape.csv">LibA-220302-pretending_S2M11_is_receptor-2 LibA-220302-S2M11-4.9314-2</a></li>
 </ul></details>
 
 </li>
@@ -253,20 +294,9 @@
 </ul></details>
 
 </li>
-<li><details><summary>receptor affinity mutation effect plots (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/pretending_S2M11_is_receptor_mut_effect.html">pretending_S2M11_is_receptor</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>receptor affinity mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/pretending_S2M11_is_receptor_mut_icXX.html">pretending_S2M11_is_receptor</a></li>
-</ul></details>
-
-</li>
 </ul>
 <h2 id="additional-analysis-specific-files">Additional analysis-specific files</h2>
+<h4 id="data-files_5">Data files</h4>
 <ul>
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/data/site_numbering_map.csv">Reference to sequential site-numbering map</a></li>
 </ul>

--- a/docs_funcs.smk
+++ b/docs_funcs.smk
@@ -44,7 +44,9 @@ def process_nested_docs_dict(d, github_blob_url):
                     f"cannot handle file extension {ext=} and {gz=} as for {val=}"
                 )
             if processed_f is not None:
-                assert processed_f not in processed_files, f"duplicate {processed_name}"
+                assert (
+                    processed_f not in processed_files
+                ), f"duplicate {processed_f}\n{d}"
                 processed_files[processed_f] = val
         elif isinstance(val, dict):
             d_links[key], pfiles = process_nested_docs_dict(val, github_blob_url)

--- a/func_effects.smk
+++ b/func_effects.smk
@@ -15,7 +15,11 @@ for selection_name, selection_d in func_scores.items():
             )
 
 # Names and values of files to add to docs
-func_effects_docs = collections.defaultdict(dict)
+func_effects_docs = {
+    "Final summary plots": collections.defaultdict(dict),
+    "Analysis notebooks": collections.defaultdict(dict),
+    "Data files": collections.defaultdict(dict),
+}
 
 
 rule func_scores:
@@ -57,7 +61,7 @@ rule func_scores:
 
 
 for s in func_scores:
-    func_effects_docs["Per-variant functional score CSVs"][
+    func_effects_docs["Data files"]["Per-variant functional score CSVs"][
         s
     ] = f"results/func_scores/{s}_func_scores.csv"
 
@@ -81,7 +85,9 @@ rule analyze_func_scores:
         "papermill {input.nb} {output.nb} &> {log}"
 
 
-func_effects_docs["Analysis of functional scores"] = rules.analyze_func_scores.output.nb
+func_effects_docs["Analysis notebooks"][
+    "Analysis of functional scores"
+] = rules.analyze_func_scores.output.nb
 
 
 rule func_effects_global_epistasis:
@@ -121,10 +127,10 @@ rule func_effects_global_epistasis:
 
 
 for s in func_scores:
-    func_effects_docs["Notebooks with per-selection global epistasis fitting"][
-        s
-    ] = f"results/notebooks/func_effects_global_epistasis_{s}.ipynb"
-    func_effects_docs["Per-selection mutation functional effect CSVs"][
+    func_effects_docs["Analysis notebooks"][
+        "Notebooks with per-selection global epistasis fitting"
+    ][s] = f"results/notebooks/func_effects_global_epistasis_{s}.ipynb"
+    func_effects_docs["Data files"]["Per-selection mutation functional effect CSVs"][
         s
     ] = f"results/func_effects/by_selection/{s}_func_effects.csv"
 
@@ -167,27 +173,35 @@ rule avg_func_effects:
         """
 
 
-func_effects_docs["Notebooks averaging mutation functional effects"] = {
+func_effects_docs["Analysis notebooks"][
+    "Notebooks averaging mutation functional effects"
+] = {
     c: f"results/notebooks/avg_func_effects_{c}.ipynb"
     for c in func_effects_config["avg_func_effects"]
 }
 
-func_effects_docs["Average mutation functional effects (CSV files)"] = {
+func_effects_docs["Data files"]["Average mutation functional effects (CSV files)"] = {
     c: f"results/func_effects/averages/{c}_func_effects.csv"
     for c in func_effects_config["avg_func_effects"]
 }
 
-func_effects_docs["Average mutation latent-phenotype effects (CSV files)"] = {
+func_effects_docs["Data files"][
+    "Average mutation latent-phenotype effects (CSV files)"
+] = {
     c: f"results/func_effects/averages/{c}_func_effects.csv"
     for c in func_effects_config["avg_func_effects"]
 }
 
-func_effects_docs["Interactive plots of average mutation functional effects"] = {
+func_effects_docs["Final summary plots"][
+    "Interactive plots of average mutation functional effects"
+] = {
     c: f"results/func_effects/averages/{c}_func_effects.html"
     for c in func_effects_config["avg_func_effects"]
 }
 
-func_effects_docs["Interactive plots of average mutation latent-phenotype effects"] = {
+func_effects_docs["Final summary plots"][
+    "Interactive plots of average mutation latent-phenotype effects"
+] = {
     c: f"results/func_effects/averages/{c}_latent_effects.html"
     for c in func_effects_config["avg_func_effects"]
 }
@@ -239,11 +253,13 @@ rule func_effect_shifts:
 
 
 if func_effect_shifts:
-    func_effects_docs["Notebooks fitting shifts in functional effects"] = {
+    func_effects_docs["Analysis notebooks"][
+        "Notebooks fitting shifts in functional effects"
+    ] = {
         c: rules.func_effect_shifts.output.nb.format(comparison=c)
         for c in func_effect_shifts
     }
-    func_effects_docs["Per-condition functional effect shifts CSVs"] = {
+    func_effects_docs["Data files"]["Per-condition functional effect shifts CSVs"] = {
         c: rules.func_effect_shifts.output.shifts.format(comparison=c)
         for c in func_effect_shifts
     }
@@ -285,15 +301,21 @@ rule avg_func_effect_shifts:
 
 
 if avg_func_effect_shifts:
-    func_effects_docs["Notebooks averaging shifts in functional effects"] = {
+    func_effects_docs["Analysis notebooks"][
+        "Notebooks averaging shifts in functional effects"
+    ] = {
         c: rules.avg_func_effect_shifts.output.nb.format(comparison=c)
         for c in avg_func_effect_shifts
     }
-    func_effects_docs["Average shifts in functional effects (CSV files)"] = {
+    func_effects_docs["Data files"][
+        "Average shifts in functional effects (CSV files)"
+    ] = {
         c: rules.avg_func_effect_shifts.output.shifts_csv.format(comparison=c)
         for c in avg_func_effect_shifts
     }
-    func_effects_docs["Interactive plots of average shifts in functional effects"] = {
+    func_effects_docs["Final summary plots"][
+        "Interactive plots of average shifts in functional effects"
+    ] = {
         c: "results/func_effect_shifts/averages/{comparison}_shifts.html".format(
             comparison=c
         )

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -42,7 +42,7 @@ def process_docs(d, depth):
             raise ValueError(f"{key=} has invalid value type {type(val)}\n{val}")
         if depth_diff <= 0:
             md_text.append(
-                init_subheading + "#" * (subheading_depth + depth_diff - 1) + entry
+                init_subheading + "##" * (subheading_depth + depth_diff - 1) + entry
             )
         else:
             md_text.append("  " * depth_diff + f"-{entry}")
@@ -68,7 +68,7 @@ html = markdown.markdown(
     extensions=[
         markdown.extensions.toc.TocExtension(
             title="Contents",
-            toc_depth="2-4",
+            toc_depth="2-2",
         ),
     ],
 )

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -23,7 +23,7 @@ md_text = [
     "",
 ]
 
-subheading_depth = 1  # keys this deep are subheadings
+subheading_depth = 2  # keys this deep are subheadings
 init_subheading = "##"  # first subheading level is this in markdown
 collapse_list = []  # nested list headings to collapse
 min_collapse_length = 1  # only collapse if at least this many entries

--- a/test_example/custom_rules.smk
+++ b/test_example/custom_rules.smk
@@ -27,7 +27,9 @@ rule spatial_distances:
 # Files (Jupyter notebooks, HTML plots, or CSVs) that you want included in
 # the HTML docs should be added to the nested dict `docs`:
 docs["Additional analysis-specific files"] = {
-    "Reference to sequential site-numbering map": config["site_numbering_map"],
+    "Data files": {
+        "Reference to sequential site-numbering map": config["site_numbering_map"],
+    },
 }
 
 # If you want to make other output files from your rules target files for


### PR DESCRIPTION
De-clutter the HTML docs by creating subsections that separate the "Final summary plots", "Analysis notebooks", and "Data files".

Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/41).