### PR TITLE
add `show_icXX_in_docs` to `antibody_escape_config` and only show ICXX if True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### version 3.4.0
+- Add `show_icXX_in_docs` key to `antibody_escape_config.yml` under `avg_assay`, and then do **not** show ICXX values in final docs if this is `False` or missing. The reason is that these values seem to be highly correlated with the escape values themselves, so there is often not much advantage showing them additionally. Furthermore, they sometime seem to be linearly correlated with validation assays but not with slope 1, making the unit-less escape value perhaps better (and so giving a reason not to show ICXX). This change is **backward incompatible** with respect to how the final HTML docs look: unless you add `show_icXX_in_docs: true` for a given assay average, it will not be shown in docs. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/52).
+
 #### version 3.3.1
 - Improve visual appearance of some site plots by making x-axis labels less crowded.
 - In `avg_escape`, plot the correlations using the same filters and metric that is being used for the final average plot. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/46).

--- a/antibody_escape.smk
+++ b/antibody_escape.smk
@@ -229,29 +229,41 @@ rule avg_escape:
 
 for assay in avg_assay_config:
     assay_str = assay.replace("_", " ")
-    for heading, sec, fname in [
+    for heading, sec, fname, is_icXX in [
         (
             f"Average selections for {assay_str}",
             "Analysis notebooks",
             rules.avg_escape.output.nb,
+            False,
         ),
-        (f"{assay_str} CSVs", "Data files", rules.avg_escape.output.effect_csv),
-        (f"{assay_str} ICXX CSVs", "Data files", rules.avg_escape.output.icXX_csv),
+        (f"{assay_str} CSVs", "Data files", rules.avg_escape.output.effect_csv, False),
+        (
+            f"{assay_str} ICXX CSVs",
+            "Data files",
+            rules.avg_escape.output.icXX_csv,
+            True,
+        ),
         (
             f"{assay_str} mutation effect plots",
             "Final summary plots",
             "results/{assay}/averages/{antibody}_mut_effect.html",
+            False,
         ),
         (
             f"{assay_str} mutation ICXX plots",
             "Final summary plots",
             "results/{assay}/averages/{antibody}_mut_icXX.html",
+            True,
         ),
     ]:
-        for antibody in avg_assay_config[assay]:
-            assay_docs[assay][sec][heading][antibody] = fname.format(
-                assay=assay, antibody=antibody
-            )
+        for antibody, antibody_config in avg_assay_config[assay].items():
+            if (not is_icXX) or (
+                ("show_icXX_in_docs" in antibody_config)
+                and antibody_config["show_icXX_in_docs"]
+            ):
+                assay_docs[assay][sec][heading][antibody] = fname.format(
+                    assay=assay, antibody=antibody
+                )
 
 for assay, assay_doc in assay_docs.items():
     if assay_doc:

--- a/docs/index.html
+++ b/docs/index.html
@@ -172,13 +172,6 @@
 </ul></details>
 
 </li>
-<li><details><summary>antibody escape mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/REGN10933_mut_icXX.html">REGN10933</a></li>
-<li><a href="htmls/S2M11_mut_icXX.html">S2M11</a></li>
-</ul></details>
-
-</li>
 </ul>
 <h4 id="analysis-notebooks_3">Analysis notebooks</h4>
 <ul>
@@ -229,13 +222,6 @@
 </ul></details>
 
 </li>
-<li><details><summary>antibody escape ICXX CSVs (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/antibody_escape/averages/REGN10933_mut_icXX.csv">REGN10933</a></li>
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/antibody_escape/averages/S2M11_mut_icXX.csv">S2M11</a></li>
-</ul></details>
-
-</li>
 </ul>
 <h2 id="receptor-affinity">Receptor affinity</h2>
 <h4 id="final-summary-plots_2">Final summary plots</h4>
@@ -243,12 +229,6 @@
 <li><details><summary>receptor affinity mutation effect plots (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="htmls/pretending_S2M11_is_receptor_mut_effect.html">pretending_S2M11_is_receptor</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>receptor affinity mutation ICXX plots (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="htmls/pretending_S2M11_is_receptor_mut_icXX.html">pretending_S2M11_is_receptor</a></li>
 </ul></details>
 
 </li>
@@ -285,12 +265,6 @@
 <li><details><summary>receptor affinity CSVs (click triangle to expand/collapse)</summary><ul>
 
 <li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/averages/pretending_S2M11_is_receptor_mut_effect.csv">pretending_S2M11_is_receptor</a></li>
-</ul></details>
-
-</li>
-<li><details><summary>receptor affinity ICXX CSVs (click triangle to expand/collapse)</summary><ul>
-
-<li><a href="https://github.com/dms-vep/dms-vep-pipeline-3/blob/main/test_example/results/receptor_affinity/averages/pretending_S2M11_is_receptor_mut_icXX.csv">pretending_S2M11_is_receptor</a></li>
 </ul></details>
 
 </li>

--- a/test_example/data/antibody_escape_config.yml
+++ b/test_example/data/antibody_escape_config.yml
@@ -262,6 +262,7 @@ receptor_selections:
 # Define defaults for each antibody/serum, used via the merge (<<) operator
 avg_antibody_escape_default: &avg_antibody_escape_default
   icXX: 90  # IC90
+  show_icXX_in_docs: false  # Do we link ICXX plots/CSVs in docs? Missing equates to false.
   escape_plot_kwargs:
     <<: *escape_plot_kwargs_default
     avg_type: median


### PR DESCRIPTION
Add `show_icXX_in_docs` key to `antibody_escape_config.yml` under `avg_assay`, and then do **not** show ICXX values in final docs if this is `False` or missing. The reason is that these values seem to be highly correlated with the escape values themselves, so there is often not much advantage showing them additionally. Furthermore, they sometime seem to be linearly correlated with validation assays but not with slope 1, making the unit-less escape value perhaps better (and so giving a reason not to show ICXX). This change is **backward incompatible** with respect to how the final HTML docs look: unless you add `show_icXX_in_docs: true` for a given assay average, it will not be shown in docs. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/52).