### PR TITLE
constrain `{chart}` wildcard in `format_altair`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.5.5
+- Fix `PeriodicWildCardError` that was raised by `snakemake` for the `_nolegend` output HTML plots for certain wildcards.
+
 #### version 3.5.4
 - Fix bug in reporting pre-selection counts cutoff in `func_scores`. See [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/87). The cutoff was applied correctly before and that has not changed, this just fixes reporting of it in plots in `analyze_func_scores`.
 

--- a/common.smk
+++ b/common.smk
@@ -6,6 +6,8 @@ include: "common_funcs.smk"
 
 rule format_altair_html:
     """Format ``altair`` charts by adding title, legend, etc."""
+    wildcard_constraints:
+        chart="((?!nolegend).)*",  # do not match, https://stackoverflow.com/a/6259570
     input:
         html="results/{chart}_nolegend.html",
         pyscript=os.path.join(config["pipeline_path"], "scripts/format_altair_html.py"),


### PR DESCRIPTION
This fixes a Periodic WildCard Error that could sometimes arise from wildcards that recursively contained _nolegend, see #171