### PR TITLE
allow VitePress config to be omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.8.1
+- Fix change to add VitePress homepage backward-compatible as originally intended by not building homepage (versus raising error) in VitePress related data totally ommitted from config.
+
 ### version 3.8.0
 - Add code and instructions on how to optionally build a nicer and more customized documentation using VitePress for hosting on GitHub Pages.
 - Update the version of `mafft` from `7.520` to `7.525` to avoid channel priority issues.

--- a/docs.smk
+++ b/docs.smk
@@ -71,7 +71,7 @@ rule build_docs:
         "scripts/build_docs.py"
 
 
-if config["build_vitepress_homepage"]:
+if "build_vitepress_homepage" in config and config["build_vitepress_homepage"]:
 
     rule build_vitepress_homepage:
         """Copy all files from the docs directory to the VitePress homepage directory"""


### PR DESCRIPTION
Fix change to add VitePress homepage backward-compatible as originally intended by not building homepage (versus raising error) in VitePress related data totally ommitted from config.