### PR TITLE
Upgrade GitHub actions to use Node 20.X

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,19 +15,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
       - run: npm run docs:build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           # Change to your GitHub Pages repository
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/homepage/README.md
+++ b/homepage/README.md
@@ -22,6 +22,12 @@ You'll need to install the Javascript packages used to build and develop the [Vi
 conda install -c conda-forge nodejs
 ```
 
+Alternatively, if you're working on `Rhino` at FHCC, you can load node as a module:
+
+```bash
+ml nodejs/20.9.0-GCCcore-13.2.0
+```
+
 You'll need to make a `package.json` file to tell `npm` which packages to install. Copy the `package.json` file from `dms-vep-pipeline-3` into the root (top level) of your project directory and run the following command to install the necessary Javascript packages:
 
 ```bash


### PR DESCRIPTION
I upgraded Node to version `20.X` in the VitePress deployment action. I decided on `20.X` over `22.X` to be consistent with the latest version of `Node` available on `Rhino`; that way, users can develop the VitePress site by loading Node with `ml nodejs/20.9.0-GCCcore-13.2.0` instead of updating their `conda` environment. I added instructions in the `README` to reflect this.