### PR TITLE
Fix issues with `Altair.vue`

### DIFF
--- a/homepage/.vitepress/theme/Altair.vue
+++ b/homepage/.vitepress/theme/Altair.vue
@@ -156,20 +156,22 @@ export default {
     flex-basis: 20%;
     text-align: left;
     font-weight: bold;
+    margin-right: 5px;
 }
 
-input[type="radio"] {
-    margin: 5px 5px 0px 10px;
+.vega-bindings select {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    text-align: center;
 }
 
-input[type="select"] {
-    margin: 5px 5px 0px 10px;
-    border: 2px solid #aaa !important;
-    border-radius: 10px;
-}
-
-input[type="select"] option {
+.vega-bindings input[type="select"] option {
     text-align: center;
     font-size: 14px;
+}
+
+.vega-bindings input[type="radio"] {
+    margin: 5px 5px 0px 10px;
 }
 </style>

--- a/homepage/.vitepress/theme/Altair.vue
+++ b/homepage/.vitepress/theme/Altair.vue
@@ -109,6 +109,7 @@ export default {
     padding: 20px;
     position: relative;
     background-color: white;
+    line-height: 0%;
 }
 
 .vega-chart-container:not(.no-box-shadow) {

--- a/homepage/.vitepress/theme/Figure.vue
+++ b/homepage/.vitepress/theme/Figure.vue
@@ -14,15 +14,13 @@ export default {
 </script>
 
 <template>
-    <p>
     <figure>
         <img v-if="imageSrc" :src="imageSrc" :alt="caption" />
         <slot v-else></slot>
         <figcaption>{{ caption }}</figcaption>
     </figure>
-    </p>
 </template>
-  
+
 <style scoped>
 figcaption {
     color: grey;


### PR DESCRIPTION
This should fix the 'hydration' issue that's duplicating the chart element. My theory is that it resulted from incorrect HTML syntax whereby a `p` tag was nested inside another `p` tag.

I also fixed the issue where the select input element in the `Altair` plot was missing a border.