### PR TITLE
Test on pull requests, deploy on pushes to main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,7 @@ jobs:
       - run: npm ci
       - run: npm run docs:build
       - name: Deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           # Change to your GitHub Pages repository


### PR DESCRIPTION
The VitePress site is only deployed on pushes to `main` to avoid the issues described [here](https://github.com/dms-vep/Flu_H5_American-Wigeon_South-Carolina_2021-H5N1_DMS/pull/108). However, the site is still built on pull requests to ensure that the site properly builds before merging into `main`.