### PR TITLE
add `duplicate_fastq_R1` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### version 3.16.0
+- Add `duplicate_fastq_R1` flag to `config.yaml` to allow the user to specify what happens if a FASTQ is duplicated among samples. Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/147).
+
 ### version 3.15.0
 - Update some packages in `conda` env (fixes [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/144)):
   - `pandas` to 2.2

--- a/Snakefile
+++ b/Snakefile
@@ -4,6 +4,7 @@ import collections
 import itertools
 import os
 import re
+import warnings
 
 import flatdict
 
@@ -44,8 +45,18 @@ dup_fastq_R1 = (
     )
     .query("n_samples > 1")
 )
-if len(dup_fastq_R1):
-    raise ValueError(f"Some FASTQs assigned to multiple samples:\n{dup_fastq_R1}")
+if "duplicate_fastq_R1" in config:
+    duplicate_fastq_R1 = config["duplicate_fastq_R1"]
+else:
+    duplicate_fastq_R1 = "raise"
+if duplicate_fastq_R1 == "raise":
+    if len(dup_fastq_R1):
+        raise ValueError(f"Some FASTQs assigned to multiple samples:\n{dup_fastq_R1}")
+elif duplicate_fastq_R1 == "warn":
+    if len(dup_fastq_R1):
+        warnings.warn(f"Some FASTQs assigned to multiple samples:\n{dup_fastq_R1}")
+elif duplicate_fastq_R1 != "ignore":
+    raise ValueError(f"invalid {duplicate_fastq_R1=}")
 
 if len(barcode_runs) > 0:
     # make sure barcode run samples start with <library>-<YYMMDD>-

--- a/Snakefile
+++ b/Snakefile
@@ -45,18 +45,14 @@ dup_fastq_R1 = (
     )
     .query("n_samples > 1")
 )
-if "duplicate_fastq_R1" in config:
-    duplicate_fastq_R1 = config["duplicate_fastq_R1"]
-else:
-    duplicate_fastq_R1 = "raise"
-if duplicate_fastq_R1 == "raise":
+if ("duplicate_fastq_R1" not in config) or (config["duplicate_fastq_R1"] == "error"):
     if len(dup_fastq_R1):
         raise ValueError(f"Some FASTQs assigned to multiple samples:\n{dup_fastq_R1}")
-elif duplicate_fastq_R1 == "warn":
+elif config["duplicate_fastq_R1"] == "warn":
     if len(dup_fastq_R1):
         warnings.warn(f"Some FASTQs assigned to multiple samples:\n{dup_fastq_R1}")
-elif duplicate_fastq_R1 != "ignore":
-    raise ValueError(f"invalid {duplicate_fastq_R1=}")
+elif config["duplicate_fastq_R1"] != "ignore":
+    raise ValueError(f"invalid {config['duplicate_fastq_R1']=}")
 
 if len(barcode_runs) > 0:
     # make sure barcode run samples start with <library>-<YYMMDD>-

--- a/test_example/config.yaml
+++ b/test_example/config.yaml
@@ -112,6 +112,11 @@ codon_variants: results/variants/codon_variants.csv
 
 barcode_runs: data/barcode_runs.csv # Illumina barcode runs, set to null if no runs
 
+# `duplicate_fastq_R1` specifies what to do if the same FASTQ is specified for multiple
+# samples in `barcode_runs`. Options are "error", "warn", or "ignore". If you
+# do not specifying `duplicate_fastq_R1` in this configuration, it defaults to "error".
+duplicate_fastq_R1: error
+
 # If the repo already includes the barcode counts tracked, and you just want to use
 # those and **not** recompute by processing the FASTQ files in `barcode_runs`, set
 # this to `true`.

--- a/test_example/data/barcode_runs.csv
+++ b/test_example/data/barcode_runs.csv
@@ -1,6 +1,6 @@
 sample,library,date,fastq_R1,notes
 LibA-220210-REGN10933-0.15-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC95_S17_R1_001.fastq.gz,
-LibA-220210-REGN10933-1.39-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC97_S19_R1_001.fastq.gz;sequencing_data/A51_REG10933_Rep1_IC95_S17_R1_001.fastq.gz,
+LibA-220210-REGN10933-1.39-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC97_S19_R1_001.fastq.gz,
 LibA-220210-REGN10933-5.58-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC99_S21_R1_001.fastq.gz,
 LibA-220210-no_antibody-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_NA_S15_R1_001.fastq.gz,
 LibA-220210-REGN10933-0.15-2,LibA,2/10/22,sequencing_data/A51_REG10933_Rep2_IC95_S18_R1_001.fastq.gz,

--- a/test_example/data/barcode_runs.csv
+++ b/test_example/data/barcode_runs.csv
@@ -1,6 +1,6 @@
 sample,library,date,fastq_R1,notes
 LibA-220210-REGN10933-0.15-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC95_S17_R1_001.fastq.gz,
-LibA-220210-REGN10933-1.39-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC97_S19_R1_001.fastq.gz,
+LibA-220210-REGN10933-1.39-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC97_S19_R1_001.fastq.gz;sequencing_data/A51_REG10933_Rep1_IC95_S17_R1_001.fastq.gz,
 LibA-220210-REGN10933-5.58-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_IC99_S21_R1_001.fastq.gz,
 LibA-220210-no_antibody-1,LibA,2/10/22,sequencing_data/A51_REG10933_Rep1_NA_S15_R1_001.fastq.gz,
 LibA-220210-REGN10933-0.15-2,LibA,2/10/22,sequencing_data/A51_REG10933_Rep2_IC95_S18_R1_001.fastq.gz,


### PR DESCRIPTION
Adds `duplicate_fastq_R1` option in `config.yaml`.

Can be set to "error", "warn" or "ignore" to specify what happens if the same FASTQ is used in multiple samples. Defaults to "error" if not specified.

This increments overall `dms-vep-pipeline-3` version to 3.16.0.

Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/147).