### PR TITLE
Allow JSON in GitHub pages docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### version 3.17.0
+- Allow JSON (`*.json`) files to be listed in the auto-rendered DOCS in the same way CSV and FASTA files can. Useful for linking to `dms-viz` JSONs.
+
 #### version 3.16.3
 - Update `snakemake`, `altair`, and `upsetplot` versions in `environment.yml`.
 

--- a/docs_funcs.smk
+++ b/docs_funcs.smk
@@ -37,7 +37,7 @@ def process_nested_docs_dict(d, github_blob_url):
             elif ext == ".html" and not gz:
                 d_links[key] = f"htmls/{base}.html"
                 processed_f = os.path.join(config["docs"], d_links[key])
-            elif ext in [".csv", ".fasta", ".fa"]:
+            elif ext in [".csv", ".fasta", ".fa", ".json"]:
                 d_links[key] = os.path.join(github_blob_url, val)
             else:
                 raise ValueError(


### PR DESCRIPTION
Allow JSON (`*.json`) files to be listed in the auto-rendered DOCS in the same way CSV and FASTA files can. Useful for linking to `dms-viz` JSONs.