### PR TITLE
Ensure `analyze_variant_counts` is in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update `conda` environment to latest versions of `altair` (5.4 -> 5.5), `baltic` (0.2.2 -> 0.3), `biopython` (1.83 -> 1.84), `entrez-direct` (16.2 -> 22.4), `markdown` (3.4 -> 3.6), `matplotlib` (3.8 -> 3.9). `minimap2` (2.26 -> 2.28), `plotnine` (0.12 -> 0.14), `python` (3.11 -> 3.12)`, `ruamel.yaml` (0.17 -> 0.18), `snakemake` (8.20.6 -> 8.25.3), `alignparse` (0.6.2 -> 0.6.3), `polyclonal` (6.12 -> 6.13), and `multidms` (0.3.3 -> 0.4.0). Note that installing `multidms` downgrades `altair` to 5.1.2 due to [this issue](https://github.com/matsengrp/multidms/issues/165).
 - Made some internal changes to code to adjust to version update of `ruamel.yaml`, as new version drops `round_trip_dump` and `safe_load`.
 - Some notebooks previously read input parameters from the YAML configuration file, which is non-ideal as it meant that `snakemake` was not explicitly tracking what was passed to them. Fixed this: now all parameters they use are passed via `papermill` parameterization.
+- Fixed [bug](https://github.com/dms-vep/dms-vep-pipeline-3/issues/164) introduced in version 3.14 that causes `analyze_variant_counts` notebook to be excluded from docs in some cases.
 - Update node version for homepage deployment and add note to README about how deployment version must match that used to create `package-lock.json` (addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/165)).
 
 ### version 3.18.0

--- a/count_variants.smk
+++ b/count_variants.smk
@@ -87,9 +87,8 @@ rule analyze_variant_counts:
         """
 
 
-if (
-    "use_precomputed_barcode_counts" in config
-    and not config["use_precomputed_barcode_counts"]
+if ("use_precomputed_barcode_counts" not in config) or (
+    not config["use_precomputed_barcode_counts"]
 ):
     count_variants_docs["Analysis notebooks"][
         "Analysis of variant counts"

--- a/docs/notebooks/analyze_variant_counts.html
+++ b/docs/notebooks/analyze_variant_counts.html
@@ -7586,7 +7586,7 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs celltag_injected-parameters" id="cell-id=ee1a9d9a">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs celltag_injected-parameters" id="cell-id=ddb9af4a">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7673,7 +7673,7 @@ a.anchor-link {
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/3779474405.py:3: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
+<pre>/tmp/ipykernel_56382/3779474405.py:3: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
 </pre>
 </div>
 </div>
@@ -7753,23 +7753,23 @@ a.anchor-link {
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed {
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed details,
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed details summary {
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed details,
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-711c408a731149d4af3e73a2c6b7ea72"></div>
+<div id="altair-viz-e210301de8f14d8e8d2b4bbc5551065e"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-711c408a731149d4af3e73a2c6b7ea72") {
-      outputDiv = document.getElementById("altair-viz-711c408a731149d4af3e73a2c6b7ea72");
+    if (outputDiv.id !== "altair-viz-e210301de8f14d8e8d2b4bbc5551065e") {
+      outputDiv = document.getElementById("altair-viz-e210301de8f14d8e8d2b4bbc5551065e");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -7898,23 +7898,23 @@ Invalid counts mean parseable barcodes that nonetheless don't map to our library
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[7]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed {
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed details,
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed details summary {
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed details,
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-f5c9fe96ebe7462994caa27610e3fd0e"></div>
+<div id="altair-viz-b744ef85eee5450e8741df41c4c07220"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-f5c9fe96ebe7462994caa27610e3fd0e") {
-      outputDiv = document.getElementById("altair-viz-f5c9fe96ebe7462994caa27610e3fd0e");
+    if (outputDiv.id !== "altair-viz-b744ef85eee5450e8741df41c4c07220") {
+      outputDiv = document.getElementById("altair-viz-b744ef85eee5450e8741df41c4c07220");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8043,23 +8043,23 @@ If so, that is a likely sign of contamination.</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed {
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed details,
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed details summary {
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed details,
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-d430bf4278454faf9ef9d3e84398af9a"></div>
+<div id="altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-d430bf4278454faf9ef9d3e84398af9a") {
-      outputDiv = document.getElementById("altair-viz-d430bf4278454faf9ef9d3e84398af9a");
+    if (outputDiv.id !== "altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a") {
+      outputDiv = document.getElementById("altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8218,23 +8218,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[9]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed {
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed details,
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed details summary {
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed details,
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-ee1d42e247dc423d94eb7072f3b4f1db"></div>
+<div id="altair-viz-3c939fa90f0c4a37b1014778c76aa80b"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-ee1d42e247dc423d94eb7072f3b4f1db") {
-      outputDiv = document.getElementById("altair-viz-ee1d42e247dc423d94eb7072f3b4f1db");
+    if (outputDiv.id !== "altair-viz-3c939fa90f0c4a37b1014778c76aa80b") {
+      outputDiv = document.getElementById("altair-viz-3c939fa90f0c4a37b1014778c76aa80b");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8358,8 +8358,8 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2559734165.py:2: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
-/tmp/ipykernel_23994/2559734165.py:7: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+<pre>/tmp/ipykernel_56382/2559734165.py:2: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+/tmp/ipykernel_56382/2559734165.py:7: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
 </pre>
 </div>
 </div>
@@ -8367,23 +8367,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[10]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed {
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed details,
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed details summary {
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed details,
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-56531506c28b4347a2898755806bdbce"></div>
+<div id="altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-56531506c28b4347a2898755806bdbce") {
-      outputDiv = document.getElementById("altair-viz-56531506c28b4347a2898755806bdbce");
+    if (outputDiv.id !== "altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b") {
+      outputDiv = document.getElementById("altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8525,7 +8525,7 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/3311838074.py:10: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+<pre>/tmp/ipykernel_56382/3311838074.py:10: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
 </pre>
 </div>
 </div>
@@ -8533,23 +8533,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[11]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed {
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed details,
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed details summary {
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed details,
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-115011bd888a4ad18a3d9a02873f9d1f"></div>
+<div id="altair-viz-95fcc291029c46f3be94d6a4b028c004"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-115011bd888a4ad18a3d9a02873f9d1f") {
-      outputDiv = document.getElementById("altair-viz-115011bd888a4ad18a3d9a02873f9d1f");
+    if (outputDiv.id !== "altair-viz-95fcc291029c46f3be94d6a4b028c004") {
+      outputDiv = document.getElementById("altair-viz-95fcc291029c46f3be94d6a4b028c004");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8671,23 +8671,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[12]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed {
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed details,
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed details summary {
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed details,
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-29f3fbd7ffb040759d7bcfe72a362823"></div>
+<div id="altair-viz-28f6ffd2be0748e2a219b9f43df3e84d"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-29f3fbd7ffb040759d7bcfe72a362823") {
-      outputDiv = document.getElementById("altair-viz-29f3fbd7ffb040759d7bcfe72a362823");
+    if (outputDiv.id !== "altair-viz-28f6ffd2be0748e2a219b9f43df3e84d") {
+      outputDiv = document.getElementById("altair-viz-28f6ffd2be0748e2a219b9f43df3e84d");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8802,14 +8802,8 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2757082629.py:9: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
-</pre>
-</div>
-</div>
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2757082629.py:17: FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas. Specify observed=False to silence this warning and retain the current behavior
+<pre>/tmp/ipykernel_56382/2757082629.py:9: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+/tmp/ipykernel_56382/2757082629.py:17: FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas. Specify observed=False to silence this warning and retain the current behavior
 </pre>
 </div>
 </div>
@@ -8898,23 +8892,23 @@ Note that you can select which libraries or dates to show with the dropdown box 
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[14]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed {
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed details,
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed details summary {
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed details,
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-e34242603cdb4661bf6ee319ad65b76f"></div>
+<div id="altair-viz-18ab381e9c1542fca31a6bafa60339d3"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-e34242603cdb4661bf6ee319ad65b76f") {
-      outputDiv = document.getElementById("altair-viz-e34242603cdb4661bf6ee319ad65b76f");
+    if (outputDiv.id !== "altair-viz-18ab381e9c1542fca31a6bafa60339d3") {
+      outputDiv = document.getElementById("altair-viz-18ab381e9c1542fca31a6bafa60339d3");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",

--- a/homepage/public/notebooks/analyze_variant_counts.html
+++ b/homepage/public/notebooks/analyze_variant_counts.html
@@ -7586,7 +7586,7 @@ a.anchor-link {
 </div>
 </div>
 </div>
-</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs celltag_injected-parameters" id="cell-id=ee1a9d9a">
+</div><div class="jp-Cell jp-CodeCell jp-Notebook-cell jp-mod-noOutputs celltag_injected-parameters" id="cell-id=ddb9af4a">
 <div class="jp-Cell-inputWrapper" tabindex="0">
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
@@ -7673,7 +7673,7 @@ a.anchor-link {
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/3779474405.py:3: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
+<pre>/tmp/ipykernel_56382/3779474405.py:3: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
 </pre>
 </div>
 </div>
@@ -7753,23 +7753,23 @@ a.anchor-link {
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed {
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed details,
-  #altair-viz-711c408a731149d4af3e73a2c6b7ea72.vega-embed details summary {
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed details,
+  #altair-viz-e210301de8f14d8e8d2b4bbc5551065e.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-711c408a731149d4af3e73a2c6b7ea72"></div>
+<div id="altair-viz-e210301de8f14d8e8d2b4bbc5551065e"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-711c408a731149d4af3e73a2c6b7ea72") {
-      outputDiv = document.getElementById("altair-viz-711c408a731149d4af3e73a2c6b7ea72");
+    if (outputDiv.id !== "altair-viz-e210301de8f14d8e8d2b4bbc5551065e") {
+      outputDiv = document.getElementById("altair-viz-e210301de8f14d8e8d2b4bbc5551065e");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -7898,23 +7898,23 @@ Invalid counts mean parseable barcodes that nonetheless don't map to our library
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[7]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed {
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed details,
-  #altair-viz-f5c9fe96ebe7462994caa27610e3fd0e.vega-embed details summary {
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed details,
+  #altair-viz-b744ef85eee5450e8741df41c4c07220.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-f5c9fe96ebe7462994caa27610e3fd0e"></div>
+<div id="altair-viz-b744ef85eee5450e8741df41c4c07220"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-f5c9fe96ebe7462994caa27610e3fd0e") {
-      outputDiv = document.getElementById("altair-viz-f5c9fe96ebe7462994caa27610e3fd0e");
+    if (outputDiv.id !== "altair-viz-b744ef85eee5450e8741df41c4c07220") {
+      outputDiv = document.getElementById("altair-viz-b744ef85eee5450e8741df41c4c07220");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8043,23 +8043,23 @@ If so, that is a likely sign of contamination.</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed {
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed details,
-  #altair-viz-d430bf4278454faf9ef9d3e84398af9a.vega-embed details summary {
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed details,
+  #altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-d430bf4278454faf9ef9d3e84398af9a"></div>
+<div id="altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-d430bf4278454faf9ef9d3e84398af9a") {
-      outputDiv = document.getElementById("altair-viz-d430bf4278454faf9ef9d3e84398af9a");
+    if (outputDiv.id !== "altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a") {
+      outputDiv = document.getElementById("altair-viz-ee4db6c7894e4d568dd1bb2e66aae53a");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8218,23 +8218,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[9]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed {
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed details,
-  #altair-viz-ee1d42e247dc423d94eb7072f3b4f1db.vega-embed details summary {
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed details,
+  #altair-viz-3c939fa90f0c4a37b1014778c76aa80b.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-ee1d42e247dc423d94eb7072f3b4f1db"></div>
+<div id="altair-viz-3c939fa90f0c4a37b1014778c76aa80b"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-ee1d42e247dc423d94eb7072f3b4f1db") {
-      outputDiv = document.getElementById("altair-viz-ee1d42e247dc423d94eb7072f3b4f1db");
+    if (outputDiv.id !== "altair-viz-3c939fa90f0c4a37b1014778c76aa80b") {
+      outputDiv = document.getElementById("altair-viz-3c939fa90f0c4a37b1014778c76aa80b");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8358,8 +8358,8 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2559734165.py:2: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
-/tmp/ipykernel_23994/2559734165.py:7: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+<pre>/tmp/ipykernel_56382/2559734165.py:2: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+/tmp/ipykernel_56382/2559734165.py:7: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
 </pre>
 </div>
 </div>
@@ -8367,23 +8367,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[10]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed {
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed details,
-  #altair-viz-56531506c28b4347a2898755806bdbce.vega-embed details summary {
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed details,
+  #altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-56531506c28b4347a2898755806bdbce"></div>
+<div id="altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-56531506c28b4347a2898755806bdbce") {
-      outputDiv = document.getElementById("altair-viz-56531506c28b4347a2898755806bdbce");
+    if (outputDiv.id !== "altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b") {
+      outputDiv = document.getElementById("altair-viz-d4b2f6984c794c62b0fcd72f6ca78a8b");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8525,7 +8525,7 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/3311838074.py:10: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+<pre>/tmp/ipykernel_56382/3311838074.py:10: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
 </pre>
 </div>
 </div>
@@ -8533,23 +8533,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[11]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed {
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed details,
-  #altair-viz-115011bd888a4ad18a3d9a02873f9d1f.vega-embed details summary {
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed details,
+  #altair-viz-95fcc291029c46f3be94d6a4b028c004.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-115011bd888a4ad18a3d9a02873f9d1f"></div>
+<div id="altair-viz-95fcc291029c46f3be94d6a4b028c004"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-115011bd888a4ad18a3d9a02873f9d1f") {
-      outputDiv = document.getElementById("altair-viz-115011bd888a4ad18a3d9a02873f9d1f");
+    if (outputDiv.id !== "altair-viz-95fcc291029c46f3be94d6a4b028c004") {
+      outputDiv = document.getElementById("altair-viz-95fcc291029c46f3be94d6a4b028c004");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8671,23 +8671,23 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[12]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed {
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed details,
-  #altair-viz-29f3fbd7ffb040759d7bcfe72a362823.vega-embed details summary {
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed details,
+  #altair-viz-28f6ffd2be0748e2a219b9f43df3e84d.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-29f3fbd7ffb040759d7bcfe72a362823"></div>
+<div id="altair-viz-28f6ffd2be0748e2a219b9f43df3e84d"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-29f3fbd7ffb040759d7bcfe72a362823") {
-      outputDiv = document.getElementById("altair-viz-29f3fbd7ffb040759d7bcfe72a362823");
+    if (outputDiv.id !== "altair-viz-28f6ffd2be0748e2a219b9f43df3e84d") {
+      outputDiv = document.getElementById("altair-viz-28f6ffd2be0748e2a219b9f43df3e84d");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",
@@ -8802,14 +8802,8 @@ Plot the average counts per variant of each target type:</p>
 <div class="jp-OutputArea-child">
 <div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
 <div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2757082629.py:9: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
-</pre>
-</div>
-</div>
-<div class="jp-OutputArea-child">
-<div class="jp-OutputPrompt jp-OutputArea-prompt"></div>
-<div class="jp-RenderedText jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" tabindex="0">
-<pre>/tmp/ipykernel_23994/2757082629.py:17: FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas. Specify observed=False to silence this warning and retain the current behavior
+<pre>/tmp/ipykernel_56382/2757082629.py:9: FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
+/tmp/ipykernel_56382/2757082629.py:17: FutureWarning: The default value of observed=False is deprecated and will change to observed=True in a future version of pandas. Specify observed=False to silence this warning and retain the current behavior
 </pre>
 </div>
 </div>
@@ -8898,23 +8892,23 @@ Note that you can select which libraries or dates to show with the dropdown box 
 <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[14]:</div>
 <div class="jp-RenderedHTMLCommon jp-RenderedHTML jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/html" tabindex="0">
 <style>
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed {
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed {
     width: 100%;
     display: flex;
   }
 
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed details,
-  #altair-viz-e34242603cdb4661bf6ee319ad65b76f.vega-embed details summary {
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed details,
+  #altair-viz-18ab381e9c1542fca31a6bafa60339d3.vega-embed details summary {
     position: relative;
   }
 </style>
-<div id="altair-viz-e34242603cdb4661bf6ee319ad65b76f"></div>
+<div id="altair-viz-18ab381e9c1542fca31a6bafa60339d3"></div>
 <script type="text/javascript">
   var VEGA_DEBUG = (typeof VEGA_DEBUG == "undefined") ? {} : VEGA_DEBUG;
   (function(spec, embedOpt){
     let outputDiv = document.currentScript.previousElementSibling;
-    if (outputDiv.id !== "altair-viz-e34242603cdb4661bf6ee319ad65b76f") {
-      outputDiv = document.getElementById("altair-viz-e34242603cdb4661bf6ee319ad65b76f");
+    if (outputDiv.id !== "altair-viz-18ab381e9c1542fca31a6bafa60339d3") {
+      outputDiv = document.getElementById("altair-viz-18ab381e9c1542fca31a6bafa60339d3");
     }
     const paths = {
       "vega": "https://cdn.jsdelivr.net/npm/vega@5?noext",


### PR DESCRIPTION
Addresses [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/164), namely a bug introduced in version 3.14 that causes `analyze_variant_counts` notebook to be excluded from docs in some cases (when `use_precomputed_barcode_counts` missing from `config.yaml`).