### PR TITLE
Fix the appearance of select boxes in VitePress/Altair embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### version 3.20.1
+- Fix [minor issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/176) w embedding Altair plots in VitePress homepage.
+
 ### version 3.20.0
 - Various updates to the `summary` plots:
   + Add option `no_mean_lineplot` to not show antibody-escape mean lineplot (see [this issue](https://github.com/dms-vep/Flu_H5_American-Wigeon_South-Carolina_2021-H5N1_DMS/issues/136)).

--- a/homepage/.vitepress/theme/Altair.vue
+++ b/homepage/.vitepress/theme/Altair.vue
@@ -164,6 +164,7 @@ export default {
     border-radius: 4px;
     background-color: #fff;
     text-align: center;
+    -webkit-appearance: auto;
 }
 
 .vega-bindings input[type="select"] option {


### PR DESCRIPTION
The select box wasn't visible in Altair plots embedded in VitePress. VitePress removes the browser-determined styling of select boxes so developers can design a custom appearance.

```css
select {
    -webkit-appearance: none;
}
```

Explicitly specifying the select box's appearance is reasonable in a complex website, but the browser defaults are fine for us, so I overwrote the VitePress styles.

```css
select {
    -webkit-appearance: auto;
}
```