### PR TITLE
enable `_default` merge keys in summaries config YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.24.0
+- Enable use of anchor and merge keys in the YAML configuration for the summaries by **not** making summary plots for any top-level key that ends with `_default`. This enables keys like `summary_default` to be defined on `summaries_config.yaml` and then used to define defaults that are merged into other summaries.
+
 #### 3.23.1
 - Address [this issue](https://github.com/dms-vep/dms-vep-pipeline-3/issues/187) by making per-replicate line plots render in `avg_escape` notebook when initial site statistic is *sum_abs* or *mean_abs*.
 

--- a/summaries.smk
+++ b/summaries.smk
@@ -2,7 +2,11 @@
 
 # read the config for the summaries
 with open(config["summaries_config"]) as f:
-    summaries_config = yaml.YAML(typ="safe", pure=True).load(f)
+    summaries_config = {
+        key: val
+        for (key, val) in yaml.YAML(typ="safe", pure=True).load(f).items()
+        if not key.endswith("_default")
+    }
 
 
 rule summary:

--- a/test_example/data/summaries_config.yml
+++ b/test_example/data/summaries_config.yml
@@ -7,10 +7,16 @@
 # Provide a different key with the name of each set of summaries
 # --------------------------------------------------------------------------------------
 
-summary_of_all_phenotypes:
+# You can use YAML anchor and merge keys to define values used for all summaries.
+# In order to enable this, any top-level key that ends with "_default" is **not**
+# used to generate a summary.
+summary_default: &summary_default
   min_times_seen: 3  # only include mutations with times_seen >= this
   min_frac_models: 1  # only include mutations in >= this fraction of models
   alphabet: [A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y, -]  # amino acids to include
+
+summary_of_all_phenotypes:
+  <<: *summary_default
   init_floor_escape_at_zero: true  # initially floor site escape to be >= 0?
   init_site_escape_stat: mean  # initially show site escape as this statistic
   lineplot_antibody_label_loc: right  # can be right or top
@@ -97,9 +103,7 @@ summary_of_just_antibodies:
       no_heatmap: True  # optional argument, do not show heatmap for this antibody set
 
 summary_of_just_entry_and_binding:
-  min_times_seen: 3  # only include mutations with times_seen >= this
-  min_frac_models: 1  # only include mutations in >= this fraction of models
-  alphabet: [A, C, D, E, F, G, H, I, K, L, M, N, P, Q, R, S, T, V, W, Y, -]  # amino acids to include
+  <<: *summary_default
   init_floor_escape_at_zero: true  # initially floor site escape to be >= 0?
   init_site_escape_stat: mean  # initially show site escape as this statistic
   antibody_escape: {}


### PR DESCRIPTION
Enable use of anchor and merge keys in the YAML configuration for the summaries by **not** making summary plots for any top-level key that ends with `_default`. This enables keys like `summary_default` to be defined on `summaries_config.yaml` and then used to define defaults that are merged into other summaries