### PR TITLE
fix target rule inputs in `Snakefile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### 3.29.1
+- Fixed the target rule in the `Snakefile`; previously it only depended on the docs so would not trigger a re-run in certain cases if just params changed or files were missing in results but not docs folder.
+
 ### 3.29.0
 - Completely changed the way the HTML documentation of the results are rendered on GitHub.
   + Summary of changes:

--- a/Snakefile
+++ b/Snakefile
@@ -136,5 +136,6 @@ include: "docs.smk"
 # target rule with everything specified in `docs` plus the actual docs directory
 rule all:
     input:
+        rules.build_docs.input,
         rules.build_publish_docs.output,
         *other_target_files,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dms-vep-pipeline-3"
-version = "3.29.0"
+version = "3.29.1"
 description = "Pipeline for analyzing deep mutational scanning (DMS) of viral entry proteins (VEPs)"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Previously re-runs were not always re-triggered when needed as only the final docs but not their input files were a target for the *all* rule in `Snakefile`. This fixes that.