### PR TITLE
Updated `polyclonal` to version 6.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+#### 3.29.2
+- Updated `polyclonal` to version 6.17 which is a minor bug fix update that addresses an issue with averaging models when using sequential integer sites (see [here](https://github.com/dms-vep/MERS-Spike-EMC2012-DMS/issues/21) and [here](https://github.com/jbloomlab/polyclonal/pull/190)).
+
 #### 3.29.1
 - Fixed the target rule in the `Snakefile`; previously it only depended on the docs so would not trigger a re-run in certain cases if just params changed or files were missing in results but not docs folder.
 

--- a/environment.yml
+++ b/environment.yml
@@ -39,4 +39,4 @@ dependencies:
       - dmslogo==0.7.0
       - multidms==0.4.2
       - neutcurve==2.1
-      - polyclonal==6.16
+      - polyclonal==6.17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dms-vep-pipeline-3"
-version = "3.29.1"
+version = "3.29.2"
 description = "Pipeline for analyzing deep mutational scanning (DMS) of viral entry proteins (VEPs)"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This is a minor bug fix update that addresses an issue with averaging models when using sequential integer sites (see [here](https://github.com/dms-vep/MERS-Spike-EMC2012-DMS/issues/21) and [here](https://github.com/jbloomlab/polyclonal/pull/190)).